### PR TITLE
Feature/tenant specific services

### DIFF
--- a/Collie.Abstractions/Collie.Abstractions.csproj
+++ b/Collie.Abstractions/Collie.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.0.11</Version>
+    <Version>1.1.0</Version>
     <Authors>Rory Murphy</Authors>
     <Description>Native interfaces for the Collie dependency injection container</Description>
     <Copyright>Rory Murphy</Copyright>

--- a/Collie.Abstractions/ServiceCatalogExtensions.cs
+++ b/Collie.Abstractions/ServiceCatalogExtensions.cs
@@ -14,37 +14,37 @@ namespace Collie.Abstractions
 
         public static IServiceCatalog AddSingleton<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory) => AddWithLifetime<TService>(services, factory, ServiceLifetime.Singleton);
 
-        public static IServiceCatalog AddTenantSingleton<TService, TImplementation>(this IServiceCatalog services) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.TenantSingleton);
+        public static IServiceCatalog AddTenantSingleton<TService, TImplementation>(this IServiceCatalog services, Func<object, bool> tenantFilter = null) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.TenantSingleton, tenantFilter);
 
-        public static IServiceCatalog AddTenantSingleton<TService>(this IServiceCatalog services, TService instance) => AddWithLifetime<TService>(services, instance, ServiceLifetime.TenantSingleton);
+        public static IServiceCatalog AddTenantSingleton<TService>(this IServiceCatalog services, TService instance, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, instance, ServiceLifetime.TenantSingleton, tenantFilter);
 
-        public static IServiceCatalog AddTenantSingleton<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory) => AddWithLifetime<TService>(services, factory, ServiceLifetime.TenantSingleton);
+        public static IServiceCatalog AddTenantSingleton<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, factory, ServiceLifetime.TenantSingleton, tenantFilter);
 
-        public static IServiceCatalog AddScoped<TService, TImplementation>(this IServiceCatalog services) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.Scoped);
+        public static IServiceCatalog AddScoped<TService, TImplementation>(this IServiceCatalog services, Func<object, bool> tenantFilter = null) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.Scoped, tenantFilter);
 
-        public static IServiceCatalog AddScoped<TService>(this IServiceCatalog services, TService instance) => AddWithLifetime<TService>(services, instance, ServiceLifetime.Scoped);
+        public static IServiceCatalog AddScoped<TService>(this IServiceCatalog services, TService instance, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, instance, ServiceLifetime.Scoped, tenantFilter);
 
-        public static IServiceCatalog AddScoped<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory) => AddWithLifetime<TService>(services, factory, ServiceLifetime.Scoped);
+        public static IServiceCatalog AddScoped<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, factory, ServiceLifetime.Scoped, tenantFilter);
 
-        public static IServiceCatalog AddTransient<TService, TImplementation>(this IServiceCatalog services) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.Transient);
+        public static IServiceCatalog AddTransient<TService, TImplementation>(this IServiceCatalog services, Func<object, bool> tenantFilter = null) where TImplementation : TService => AddWithLifetime<TService, TImplementation>(services, ServiceLifetime.Transient, tenantFilter);
 
-        public static IServiceCatalog AddTransient<TService>(this IServiceCatalog services, TService instance) => AddWithLifetime<TService>(services, instance, ServiceLifetime.Transient);
+        public static IServiceCatalog AddTransient<TService>(this IServiceCatalog services, TService instance, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, instance, ServiceLifetime.Transient, tenantFilter);
 
-        public static IServiceCatalog AddTransient<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory) => AddWithLifetime<TService>(services, factory, ServiceLifetime.Transient);
+        public static IServiceCatalog AddTransient<TService>(this IServiceCatalog services, Func<IServiceContainer, TService> factory, Func<object, bool> tenantFilter = null) => AddWithLifetime<TService>(services, factory, ServiceLifetime.Transient, tenantFilter);
 
-        private static IServiceCatalog AddWithLifetime<TService, TImplementation>(IServiceCatalog services, ServiceLifetime lifetime)
+        private static IServiceCatalog AddWithLifetime<TService, TImplementation>(IServiceCatalog services, ServiceLifetime lifetime, Func<object, bool> tenantFilter = null)
         {
-            services.Add(new ServiceDefinition(typeof(TService), lifetime, typeof(TImplementation)));
+            services.Add(new ServiceDefinition(typeof(TService), lifetime, typeof(TImplementation)) { TenantFilter = tenantFilter });
             return services;
         }
 
-        public static IServiceCatalog AddWithLifetime<TService>(IServiceCatalog services, TService instance, ServiceLifetime lifetime)
+        public static IServiceCatalog AddWithLifetime<TService>(IServiceCatalog services, TService instance, ServiceLifetime lifetime, Func<object, bool> tenantFilter = null)
         {
-            services.Add(new ServiceDefinition(typeof(TService), lifetime, instance));
+            services.Add(new ServiceDefinition(typeof(TService), lifetime, instance) { TenantFilter = tenantFilter });
             return services;
         }
 
-        public static IServiceCatalog AddWithLifetime<TService>(IServiceCatalog services, Func<IServiceContainer, TService> factory, ServiceLifetime lifetime)
+        public static IServiceCatalog AddWithLifetime<TService>(IServiceCatalog services, Func<IServiceContainer, TService> factory, ServiceLifetime lifetime, Func<object, bool> tenantFilter = null)
         {
             if(services == null) { throw new ArgumentNullException(nameof(services)); }
             if (factory == null) { throw new ArgumentNullException(nameof(factory)); }
@@ -52,7 +52,7 @@ namespace Collie.Abstractions
             var objFactory = factory as Func<IServiceContainer, object>;
             objFactory = objFactory ?? ((IServiceContainer c) => (object)factory(c));
 
-            services.Add(new ServiceDefinition(typeof(TService), lifetime, objFactory));
+            services.Add(new ServiceDefinition(typeof(TService), lifetime, objFactory) { TenantFilter = tenantFilter });
             return services;
         }
     }

--- a/Collie.Abstractions/ServiceDefinition.cs
+++ b/Collie.Abstractions/ServiceDefinition.cs
@@ -37,6 +37,8 @@ namespace Collie.Abstractions
 
         public Type ServiceType { get; init; }
 
+        public Func<object, bool> TenantFilter { get; init; }
+
         public Type ImplementationType { get; init; }
 
         public ServiceLifetime Lifetime { get; init; }

--- a/Collie.Compatibility.Abstractions/Collie.Compatibility.Abstractions.csproj
+++ b/Collie.Compatibility.Abstractions/Collie.Compatibility.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <Version>1.0.11</Version>
+    <Version>1.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/rorymurphy/collie</PackageProjectUrl>

--- a/Collie.Compatibility.Abstractions/ServiceCollectionExtensions.cs
+++ b/Collie.Compatibility.Abstractions/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Collie.Compatibility.Abstractions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddScoped<TService, TImplementation>(this IServiceCollection services, Func<object, bool> tenantFilter) where TImplementation : TService
+        {
+            services.Add(new TenantFilteringServiceDescriptor(typeof(TService), typeof(TImplementation), ServiceLifetime.Scoped) { TenantFilter = tenantFilter});
+            return services;
+        }
+
+        public static IServiceCollection AddScoped<TService>(this IServiceCollection services, Func<IServiceProvider, object> factory, Func<object, bool> tenantFilter)
+        {
+            services.Add(new TenantFilteringServiceDescriptor(typeof(TService), factory, ServiceLifetime.Scoped) { TenantFilter = tenantFilter });
+            return services;
+        }
+    }
+}

--- a/Collie.Compatibility.Abstractions/ServiceCollectionExtensions.cs
+++ b/Collie.Compatibility.Abstractions/ServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Collie.Compatibility.Abstractions
+namespace Collie.Compatibility
 {
     public static class ServiceCollectionExtensions
     {

--- a/Collie.Compatibility.Abstractions/TenantFilteringServiceDescriptor.cs
+++ b/Collie.Compatibility.Abstractions/TenantFilteringServiceDescriptor.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Collie.Compatibility
+{
+    public class TenantFilteringServiceDescriptor : ServiceDescriptor
+    {
+        public TenantFilteringServiceDescriptor(Type serviceType, object instance) : base(serviceType, instance) { }
+
+        public TenantFilteringServiceDescriptor(Type serviceType, Type implementationType, ServiceLifetime lifetime) : base(serviceType, implementationType, lifetime) { }
+
+        public TenantFilteringServiceDescriptor(Type serviceType, Func<IServiceProvider, object> factory, ServiceLifetime lifetime) : base(serviceType, factory, lifetime) { }
+
+        public Func<object, bool> TenantFilter { get; init; }
+    }
+}

--- a/Collie.Compatibility.Abstractions/TenantSingletonServiceCollectionExtensions.cs
+++ b/Collie.Compatibility.Abstractions/TenantSingletonServiceCollectionExtensions.cs
@@ -10,18 +10,18 @@ namespace Collie
 {
     public static class TenantSingletonServiceCollectionExtensions
     {
-        public static IServiceCollection AddTenantSingleton<TService, TImplementation>(this IServiceCollection services)
+        public static IServiceCollection AddTenantSingleton<TService, TImplementation>(this IServiceCollection services, Func<object, bool> tenantFilter = null)
         {
-            services.Add(new TenantSingletonServiceDescriptor(typeof(TService), typeof(TImplementation)));
+            services.Add(new TenantSingletonServiceDescriptor(typeof(TService), typeof(TImplementation)) { TenantFilter = tenantFilter });
             return services;
         }
 
-        public static IServiceCollection AddTenantSingleton<TService>(this IServiceCollection services, Func<IServiceProvider, TService> factory)
+        public static IServiceCollection AddTenantSingleton<TService>(this IServiceCollection services, Func<IServiceProvider, TService> factory, Func<object, bool> tenantFilter = null)
         {
             var serviceType = typeof(TService);
             Func<IServiceProvider, object> objFactory = provider => (object)factory(provider);
 
-            services.Add(new TenantSingletonServiceDescriptor(typeof(TService), objFactory));
+            services.Add(new TenantSingletonServiceDescriptor(typeof(TService), objFactory) { TenantFilter = tenantFilter });
             return services;
         }
 

--- a/Collie.Compatibility.Abstractions/TenantSingletonServiceDescriptor.cs
+++ b/Collie.Compatibility.Abstractions/TenantSingletonServiceDescriptor.cs
@@ -3,10 +3,11 @@ using System;
 
 namespace Collie.Compatibility
 {
-    public class TenantSingletonServiceDescriptor : ServiceDescriptor
+    public class TenantSingletonServiceDescriptor : TenantFilteringServiceDescriptor
     {
         public TenantSingletonServiceDescriptor(Type serviceType, Func<IServiceProvider, object> factory) : base(serviceType, factory, ServiceLifetime.Scoped) { }
 
         public TenantSingletonServiceDescriptor(Type serviceType, Type implementationType) : base(serviceType, implementationType, ServiceLifetime.Scoped) { }
+
     }
 }

--- a/Collie.Compatibility.Test/Class1.cs
+++ b/Collie.Compatibility.Test/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Collie.Compatibility.Test
-{
-    public class Class1
-    {
-    }
-}

--- a/Collie.Compatibility/Collie.Compatibility.csproj
+++ b/Collie.Compatibility/Collie.Compatibility.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.11</Version>
+    <Version>1.1.0</Version>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/rorymurphy/collie</PackageProjectUrl>
     <Authors>Rory Murphy</Authors>

--- a/Collie/Collie.csproj
+++ b/Collie/Collie.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.0.11</Version>
+    <Version>1.1.0</Version>
     <PackageProjectUrl>https://github.com/rorymurphy/collie</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rorymurphy/collie</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/Collie/Compatibility/ServiceCollectionExtensions.cs
+++ b/Collie/Compatibility/ServiceCollectionExtensions.cs
@@ -17,11 +17,13 @@ namespace Collie
         {
             var catalog = new ServiceCatalog(services.Select(svc =>
             {
+                var tfSvc = svc as TenantFilteringServiceDescriptor;
                 return new ServiceDefinition(svc.ServiceType, GetServiceLifetime(svc))
                 {
                     ImplementationType = svc.ImplementationType,
                     ServiceFactory = (svc.ImplementationFactory != null) ? sc => svc.ImplementationFactory((IServiceProvider)sc) : null,
-                    ServiceInstance = svc.ImplementationInstance
+                    ServiceInstance = svc.ImplementationInstance,
+                    TenantFilter = (tfSvc != null) ? tfSvc.TenantFilter : null
                 };
             }));
 


### PR DESCRIPTION
Minor version increment to 1.1.0
Added support for TenantFilters, allowing services to be registered for only specific tenants. Applies only to TenantSingleton, Scoped and Transient lifetimes.